### PR TITLE
feat(jupyter): Support hiding image registry/version

### DIFF
--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-image/form-image.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-image/form-image.component.html
@@ -20,7 +20,7 @@
     <mat-label>Image</mat-label>
     <mat-select placeholder="Docker Image" formControlName="image">
       <mat-option *ngFor="let img of images" [value]="img">
-        {{ img }}
+        {{ imageDisplayName(img) }}
       </mat-option>
     </mat-select>
   </mat-form-field>

--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-image/form-image.component.ts
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-image/form-image.component.ts
@@ -10,8 +10,26 @@ export class FormImageComponent implements OnInit {
   @Input() parentForm: FormGroup;
   @Input() images: string[];
   @Input() readonly: boolean;
+  @Input() hideRegistry: boolean;
+  @Input() hideVersion: boolean;
 
   constructor() {}
 
   ngOnInit() {}
+
+  imageDisplayName(image: string): string {
+    const [name, version = null] = image.split(':');
+    let tokens = name.split('/')
+
+    if (this.hideRegistry && tokens.length > 1 && tokens[0].includes('.')) {
+      tokens.shift();
+    }
+    let displayName = tokens.join('/');
+
+    if (!this.hideVersion && version !== null) {
+      displayName = `${displayName}:${version}`;
+    }
+
+    return displayName;
+  }
 }

--- a/components/jupyter-web-app/frontend/src/app/resource-form/resource-form.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/resource-form.component.html
@@ -8,6 +8,8 @@
         [parentForm]="formCtrl"
         [images]="config?.image?.options"
         [readonly]="config?.image?.readOnly"
+        [hideRegistry]="config?.image?.hideRegistry"
+        [hideVersion]="config?.image?.hideVersion"
       ></app-form-image>
 
       <app-form-specs [parentForm]="formCtrl"></app-form-specs>


### PR DESCRIPTION
Adds two new configuration options to the jupyter-web-app's supported
`spawnerFormDefaults`:
  * `hideRegistry`
  * `hideVersion`

If set to `true`, the notebook spawner UI will now hide these portions
of the image tags in the list of available images. Options were set to
"hide" rather than "show" for backwards compatability: the absence of
the values will default to `false`, which results in the original
behaviour of showing the entire image tag.

Closes #1