### PR TITLE
feat(centraldashboard): Manage multiple profiles

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -320,7 +320,20 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             platform, user, namespaces, isClusterAdmin,
         } = responseEvent.detail.response;
         Object.assign(this, {user, isClusterAdmin});
-        this.namespaces = namespaces;
+        const ownerRoleNamespaces = [];
+        const otherRoleNamespaces = [];
+        for (let i = 0; i < namespaces.length; i++) {
+            if (namespaces[i].role == 'owner') {
+                ownerRoleNamespaces.push(
+                    namespaces[i],
+                );
+            } else {
+                otherRoleNamespaces.push(
+                    namespaces[i],
+                );
+            }
+        }
+        this.namespaces = ownerRoleNamespaces.concat(otherRoleNamespaces);
         if (this.namespaces.length) {
             this._setRegistrationFlow(false);
         } else if (this.isolationMode == 'single-user') {
@@ -328,6 +341,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             this._setRegistrationFlow(true);
         }
         this.ownedNamespace = namespaces.find((n) => n.role == 'owner');
+        this.multiOwnedNamespaces = ownerRoleNamespaces;
         this.platformInfo = platform;
         const kVer = this.platformInfo.kubeflowVersion;
         if (kVer && kVer != 'unknown') {

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -68,7 +68,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                 neon-animatable(page='activity')
                     activity-view(namespace='[[queryParams.ns]]')
                 neon-animatable(page='manage-users')
-                    manage-users-view(user='[[user]]', namespaces='[[namespaces]]', multi-owned-namespaces='[[multiOwnedNamespaces]]', is-cluster-admin='[[isClusterAdmin]]', owned-namespace='[[ownedNamespace]]')
+                    manage-users-view(user='[[user]]', namespaces='[[namespaces]]', multi-owned-namespaces='[[multiOwnedNamespaces]]', is-cluster-admin='[[isClusterAdmin]]')
                 neon-animatable(page='iframe')
                     iframe-container(namespace='[[namespace]]',
                         src='[[iframeSrc]]', page="{{iframePage}}")

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -68,7 +68,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                 neon-animatable(page='activity')
                     activity-view(namespace='[[queryParams.ns]]')
                 neon-animatable(page='manage-users')
-                    manage-users-view(user='[[user]]', namespaces='[[namespaces]]', is-cluster-admin='[[isClusterAdmin]]', owned-namespace='[[ownedNamespace]]')
+                    manage-users-view(user='[[user]]', namespaces='[[namespaces]]', multi-owned-namespaces='[[multiOwnedNamespaces]]', is-cluster-admin='[[isClusterAdmin]]', owned-namespace='[[ownedNamespace]]')
                 neon-animatable(page='iframe')
                     iframe-container(namespace='[[namespace]]',
                         src='[[iframeSrc]]', page="{{iframePage}}")

--- a/components/centraldashboard/public/components/manage-users-view-contributor.css
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.css
@@ -1,10 +1,6 @@
 :host {
-    @apply --layout-fit;
     background: white;
-    --content-color: #717479;
-    --subheading-color: #404447;
-    overflow: auto;
-    @apply --layout-fit;
+    position: relative;
 }
 h1, h2 {
     font-family: Google Sans;
@@ -15,9 +11,6 @@ h1 {
     color: black;
     padding: 1rem;
     border-bottom: 1px solid var(--border-color);
-}
-#Main-Content {
-    padding: 1rem;
 }
 article:not(:first-of-type) {
     margin-top: 1.5em;
@@ -44,16 +37,17 @@ h2 .icon {
 .content.small {
     max-width: 640px;
 }
-vaadin-grid {
-    --lumo-font-size-m: 1em;
-    --lumo-body-text-color: currentColor;
-    --lumo-space-m: 0
+#ContribError {
+    background: #F44336
 }
-vaadin-grid > [slot$='content-0'],
-    vaadin-grid > [slot$='content-1'],
-    vaadin-grid > [slot$='content-2'] {
-    color: var(--subheading-color);
+.contributor {
+    @apply --layout-horizontal;
+    position: relative;
+    padding: .5em;
+    flex-wrap: wrap;
+    border: 2px solid var(--action-color);
+    border-radius: 3px;
+    transition: border-color .25s;
+    display: block;
 }
-#NoNamespaceError {margin-top: 1em}
-
 [hidden] {display: none !important}

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -1,0 +1,112 @@
+import '@polymer/iron-ajax/iron-ajax.js';
+import '@polymer/iron-icon/iron-icon.js';
+import '@polymer/iron-icons/iron-icons.js';
+import '@polymer/iron-icons/social-icons.js';
+import '@polymer/paper-toast/paper-toast.js';
+import '@polymer/paper-ripple/paper-ripple.js';
+import '@polymer/paper-item/paper-icon-item.js';
+import '@polymer/paper-icon-button/paper-icon-button.js';
+
+import {html, PolymerElement} from '@polymer/polymer';
+
+import './resources/paper-chip.js';
+import './resources/md2-input/md2-input.js';
+import css from './manage-users-view-contributor.css';
+import template from './manage-users-view-contributor.pug';
+import utilitiesMixin from './utilities-mixin.js';
+
+export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
+    static get template() {
+        return html([`
+            <style>${css.toString()}</style>
+            ${template()}
+        `]);
+    }
+
+    /**
+     * Object describing property-related metadata used by Polymer features
+     */
+    static get properties() {
+        return {
+            user: {type: String, value: 'Loading...'},
+            namespaces: Array,
+            ownedNamespace: {type: Object, value: () => ({})},
+            newContribEmail: String,
+            contribError: Object,
+            contributorInputEl: Object,
+        };
+    }
+    /**
+     * Main ready method for Polymer Elements.
+     */
+    ready() {
+        super.ready();
+        this.contributorInputEl = this.$.ContribEmail;
+    }
+
+    /**
+     * Triggers an API call to create a new Contributor
+     */
+    addNewContrib() {
+        // Need to call the api directly here.
+        const api = this.$.AddContribAjax;
+        api.body = {contributor: this.newContribEmail};
+        api.generateRequest();
+    }
+    /**
+     * Triggers an API call to remove a Contributor
+     * @param {Event} e
+     */
+    removeContributor(e) {
+        const api = this.$.RemoveContribAjax;
+        api.body = {contributor: e.model.item};
+        api.generateRequest();
+    }
+    /**
+     * Takes an event from iron-ajax and isolates the error from a request that
+     * failed
+     * @param {IronAjaxEvent} e
+     * @return {string}
+     */
+    _isolateErrorFromIronRequest(e) {
+        const bd = e.detail.request.response||{};
+        return bd.error || e.detail.error || e.detail;
+    }
+    /**
+     * Iron-Ajax response / error handler for addNewContributor
+     * @param {IronAjaxEvent} e
+     */
+    handleContribCreate(e) {
+        if (e.detail.error) {
+            const error = this._isolateErrorFromIronRequest(e);
+            this.contribCreateError = error;
+            return;
+        }
+        this.contributorList = e.detail.response;
+        this.newContribEmail = this.contribCreateError = '';
+    }
+    /**
+     * Iron-Ajax response / error handler for removeContributor
+     * @param {IronAjaxEvent} e
+     */
+    handleContribDelete(e) {
+        if (e.detail.error) {
+            const error = this._isolateErrorFromIronRequest(e);
+            this.contribCreateError = error;
+            return;
+        }
+        this.contributorList = e.detail.response;
+        this.newContribEmail = this.contribCreateError = '';
+    }
+    /**
+     * Iron-Ajax error handler for getContributors
+     * @param {IronAjaxEvent} e
+     */
+    onContribFetchError(e) {
+        const error = this._isolateErrorFromIronRequest(e);
+        this.contribError = error;
+        this.$.ContribError.show();
+    }
+}
+/* eslint-disable max-len */
+customElements.define('manage-users-view-contributor', ManageUsersViewContributor);

--- a/components/centraldashboard/public/components/manage-users-view-contributor.pug
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.pug
@@ -1,0 +1,21 @@
+.contributor
+    iron-ajax#RemoveContribAjax(method='DELETE', url='/api/workgroup/remove-contributor/[[ownedNamespace.namespace]]',
+        on-response='handleContribDelete', on-error='handleContribDelete', handle-as='json', content-type='application/json')
+    iron-ajax#AddContribAjax(method='POST', url='/api/workgroup/add-contributor/[[ownedNamespace.namespace]]',
+        on-response='handleContribCreate', on-error='handleContribCreate', handle-as='json', content-type='application/json')
+    iron-ajax#GetContribsAjax(auto='[[!empty(ownedNamespace)]]', url='/api/workgroup/get-contributors/[[ownedNamespace.namespace]]',
+                last-response='{{contributorList}}', on-error='onContribFetchError', handle-as='json')   
+    h2
+        iron-icon.icon(icon='kubeflow:namespace')
+        span.text Contributors to your namespace - [[ownedNamespace.namespace]]
+    .content.small
+        md2-input(label='Email Addresses', value='{{newContribEmail}}', on-submit='addNewContrib', placeholder='Add by email address', error$='[[contribCreateError]]')
+            .prefix(slot='prefix')
+                template(is='dom-repeat', items='[[contributorList]]')
+                    paper-chip(on-remove='removeContributor') [[item]]
+    paper-toast#ContribError(duration=5000)
+        | Failed to fetch contributor list for {{ownedNamespace.namespace}}, because: 
+        strong [[contribError]]
+    paper-toast#AllNamespaceError(duration=5000)
+        | Failed to fetch all namespaces, because:
+        strong [[allNamespaceError]]

--- a/components/centraldashboard/public/components/manage-users-view-contributor_test.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor_test.js
@@ -1,0 +1,155 @@
+/* eslint-disable max-len */
+import '@polymer/test-fixture/test-fixture';
+import 'jasmine-ajax';
+import {mockIronAjax, yieldForRequests} from '../ajax_test_helper';
+import {flush} from '@polymer/polymer/lib/utils/flush.js';
+
+import './dashboard-view';
+
+const FIXTURE_ID = 'manage-users-view-contributor-fixture';
+const MU_VIEW_SELECTOR_ID = 'test-manage-users-contributor-view';
+const TEMPLATE = `
+<test-fixture id="${FIXTURE_ID}">
+  <template>
+    <manage-users-view-contributor id="${MU_VIEW_SELECTOR_ID}"></manage-users-view-contributor>
+  </template>
+</test-fixture>
+`;
+const user = 'test@kubeflow.org';
+const oNs = {namespace: 'ns1', role: 'owner'};
+const generalNs = [oNs, {namespace: 'ns2', role: 'contributor', user}, {namespace: 'ns3', role: 'contributor', user}];
+
+describe('Manage Users View Contributor', () => {
+    let manageUsersView;
+
+    beforeAll(() => {
+        jasmine.Ajax.install();
+        const div = document.createElement('div');
+        div.innerHTML = TEMPLATE;
+        document.body.appendChild(div);
+    });
+
+    beforeEach(() => {
+        document.getElementById(FIXTURE_ID).create();
+        manageUsersView = document.getElementById(MU_VIEW_SELECTOR_ID);
+    });
+
+    afterEach(() => {
+        document.getElementById(FIXTURE_ID).restore();
+    });
+
+    afterAll(() => {
+        jasmine.Ajax.uninstall();
+    });   
+
+    it('Should handle errors correctly', async () => {
+        mockIronAjax(
+            manageUsersView.$.GetContribsAjax,
+            'Failed for test',
+            true,
+        );
+
+        manageUsersView.user = user;
+        manageUsersView.ownedNamespace = oNs;
+        manageUsersView.namespaces = [oNs];
+
+        flush();
+        await yieldForRequests();
+
+        expect(manageUsersView.$.ContribError.opened)
+            .toBe(
+                true,
+                'Error toast is not opened'
+            );
+        expect(manageUsersView.contribError)
+            .toBe('Failed for test');
+    });
+
+    it('Should add contributors correctly', async () => {
+        const contribList = ['foo@kubeflow.org', 'bar@kubeflow.org'];
+        const verificationContribs = ['ap@kubeflow.org'];
+        mockIronAjax(
+            manageUsersView.$.GetContribsAjax,
+            contribList,
+        );
+        mockIronAjax(
+            manageUsersView.$.AddContribAjax,
+            verificationContribs,
+        );
+
+        manageUsersView.user = user;
+        manageUsersView.ownedNamespace = oNs;
+        manageUsersView.namespaces = generalNs;
+
+        flush();
+        await yieldForRequests();
+
+        const input = manageUsersView.shadowRoot.querySelector('.contributor md2-input');
+        input.value = 'new@google.com';
+        input.fireEnter();
+
+        await yieldForRequests();
+
+        expect(manageUsersView.contributorList)
+            .toEqual(
+                verificationContribs,
+                'Invalid list of contributors'
+            );
+    });
+
+    it('Should remove contributors correctly', async () => {
+        const contribList = ['foo@kubeflow.org', 'bar@kubeflow.org'];
+        const verificationContribs = ['ap@kubeflow.org'];
+        mockIronAjax(
+            manageUsersView.$.GetContribsAjax,
+            contribList,
+        );
+        mockIronAjax(
+            manageUsersView.$.RemoveContribAjax,
+            verificationContribs,
+        );
+
+        manageUsersView.user = user;
+        manageUsersView.ownedNamespace = oNs;
+        manageUsersView.namespaces = generalNs;
+
+        flush();
+        await yieldForRequests();
+
+        const chip = manageUsersView.shadowRoot.querySelector('.contributor md2-input paper-chip:nth-of-type(1)');
+        chip.fireRemove({});
+
+        await yieldForRequests();
+
+        expect(manageUsersView.contributorList)
+            .toEqual(
+                verificationContribs,
+                'Invalid list of contributors'
+            );
+    });
+
+    it('UI State should show contribs when namespace available', async () => {
+        const contribList = ['foo@kubeflow.org', 'bar@kubeflow.org'];
+        mockIronAjax(
+            manageUsersView.$.GetContribsAjax,
+            contribList,
+        );
+
+        manageUsersView.user = user;
+        manageUsersView.ownedNamespace = oNs;
+        manageUsersView.namespaces = generalNs;
+
+        flush();
+        await yieldForRequests();
+
+        expect(manageUsersView.shadowRoot.querySelector('.contributor > h2 > .text').innerText)
+            .toBe('Contributors to your namespace - ns1');
+
+        // View prop expectations
+        expect(manageUsersView.contributorList)
+            .toEqual(
+                contribList,
+                'Invalid list of contributors'
+            );
+    });
+});

--- a/components/centraldashboard/public/components/manage-users-view.js
+++ b/components/centraldashboard/public/components/manage-users-view.js
@@ -48,25 +48,32 @@ export class ManageUsersView extends utilitiesMixin(PolymerElement) {
         this.contributorInputEl = this.$.ContribEmail;
     }
     /**
-     * Returns 1 to 2 rows containing owner and contributor rows for namespaces
+     * Returns namespaces and roles
      * @param {[object]} ns Namespaces array.
      * @return {[string, [string]]} rows for namespace table.
      */
     nsBreakdown(ns) {
         const {ownedNamespace, namespaces} = this;
         if (!ownedNamespace || !namespaces) return;
-        const arr = [
-            [ownedNamespace.namespace, 'Owner'],
-        ];
-        if (ns.length <= 1) return arr;
-        const otherNamespaces = namespaces
-            .filter((n) => n != ownedNamespace)
-            .map((i) => i.namespace).join(', ');
-        arr.push(
-            [otherNamespaces, 'Contributor'],
-        );
+        const arr = [];
+        for (let i = 0; i < namespaces.length; i++) {
+            arr.push(
+                [namespaces[i].namespace,
+                    this.uppercaseFirst(namespaces[i].role)],
+            );
+        }
         return arr;
     }
+
+    /**
+     * Used to uppercase the first letter of the role name
+     * @param {string} string A string
+     * @return {string} A string where the first character is capitalized
+     */
+    uppercaseFirst(string) {
+        return string.charAt(0).toUpperCase() + string.slice(1);
+    }
+
     /**
      * Triggers an API call to create a new Contributor
      */

--- a/components/centraldashboard/public/components/manage-users-view.js
+++ b/components/centraldashboard/public/components/manage-users-view.js
@@ -12,8 +12,7 @@ import '@vaadin/vaadin-grid/vaadin-grid-sort-column.js';
 
 import {html, PolymerElement} from '@polymer/polymer';
 
-import './resources/paper-chip.js';
-import './resources/md2-input/md2-input.js';
+import './manage-users-view-contributor.js';
 import css from './manage-users-view.css';
 import template from './manage-users-view.pug';
 import utilitiesMixin from './utilities-mixin.js';
@@ -34,27 +33,25 @@ export class ManageUsersView extends utilitiesMixin(PolymerElement) {
             user: {type: String, value: 'Loading...'},
             isClusterAdmin: {type: Boolean, value: false},
             namespaces: Array,
-            ownedNamespace: {type: Object, value: () => ({})},
-            newContribEmail: String,
-            contribError: Object,
-            contributorInputEl: Object,
+            multiOwnedNamespaces: {type: Array, value: []},
         };
     }
+    
     /**
      * Main ready method for Polymer Elements.
      */
     ready() {
         super.ready();
-        this.contributorInputEl = this.$.ContribEmail;
     }
+    
     /**
      * Returns namespaces and roles
      * @param {[object]} ns Namespaces array.
      * @return {[string, [string]]} rows for namespace table.
      */
     nsBreakdown(ns) {
-        const {ownedNamespace, namespaces} = this;
-        if (!ownedNamespace || !namespaces) return;
+        const {namespaces} = this;
+        if (!namespaces) return;
         const arr = [];
         for (let i = 0; i < namespaces.length; i++) {
             arr.push(
@@ -75,23 +72,6 @@ export class ManageUsersView extends utilitiesMixin(PolymerElement) {
     }
 
     /**
-     * Triggers an API call to create a new Contributor
-     */
-    addNewContrib() {
-        const api = this.$.AddContribAjax;
-        api.body = {contributor: this.newContribEmail};
-        api.generateRequest();
-    }
-    /**
-     * Triggers an API call to remove a Contributor
-     * @param {Event} e
-     */
-    removeContributor(e) {
-        const api = this.$.RemoveContribAjax;
-        api.body = {contributor: e.model.item};
-        api.generateRequest();
-    }
-    /**
      * Takes an event from iron-ajax and isolates the error from a request that
      * failed
      * @param {IronAjaxEvent} e
@@ -101,41 +81,7 @@ export class ManageUsersView extends utilitiesMixin(PolymerElement) {
         const bd = e.detail.request.response||{};
         return bd.error || e.detail.error || e.detail;
     }
-    /**
-     * Iron-Ajax response / error handler for addNewContributor
-     * @param {IronAjaxEvent} e
-     */
-    handleContribCreate(e) {
-        if (e.detail.error) {
-            const error = this._isolateErrorFromIronRequest(e);
-            this.contribCreateError = error;
-            return;
-        }
-        this.contributorList = e.detail.response;
-        this.newContribEmail = this.contribCreateError = '';
-    }
-    /**
-     * Iron-Ajax response / error handler for removeContributor
-     * @param {IronAjaxEvent} e
-     */
-    handleContribDelete(e) {
-        if (e.detail.error) {
-            const error = this._isolateErrorFromIronRequest(e);
-            this.contribCreateError = error;
-            return;
-        }
-        this.contributorList = e.detail.response;
-        this.newContribEmail = this.contribCreateError = '';
-    }
-    /**
-     * Iron-Ajax error handler for getContributors
-     * @param {IronAjaxEvent} e
-     */
-    onContribFetchError(e) {
-        const error = this._isolateErrorFromIronRequest(e);
-        this.contribError = error;
-        this.$.ContribError.show();
-    }
+
     /**
      * Iron-Ajax error handler for getContributors
      * @param {IronAjaxEvent} e
@@ -147,12 +93,12 @@ export class ManageUsersView extends utilitiesMixin(PolymerElement) {
     }
     /**
      * [ComputedProp] Should the ajax call for all namespaces run?
-     * @param {object} ownedNamespace
+     * @param {object} multiOwnedNamespaces
      * @param {boolean} isClusterAdmin
      * @return {boolean}
      */
-    shouldFetchAllNamespaces(ownedNamespace, isClusterAdmin) {
-        return isClusterAdmin && !this.empty(ownedNamespace);
+    shouldFetchAllNamespaces(multiOwnedNamespaces, isClusterAdmin) {
+        return isClusterAdmin && !this.empty(multiOwnedNamespaces);
     }
 }
 

--- a/components/centraldashboard/public/components/manage-users-view.pug
+++ b/components/centraldashboard/public/components/manage-users-view.pug
@@ -3,8 +3,6 @@ iron-ajax#RemoveContribAjax(method='DELETE', url='/api/workgroup/remove-contribu
     on-response='handleContribDelete', on-error='handleContribDelete', handle-as='json', content-type='application/json')
 iron-ajax#AddContribAjax(method='POST', url='/api/workgroup/add-contributor/[[ownedNamespace.namespace]]',
     on-response='handleContribCreate', on-error='handleContribCreate', handle-as='json', content-type='application/json')
-iron-ajax#GetContribsAjax(auto='[[!empty(ownedNamespace)]]', url='/api/workgroup/get-contributors/[[ownedNamespace.namespace]]',
-    last-response='{{contributorList}}', on-error='onContribFetchError', handle-as='json')
 iron-ajax#GetAllNamespacesAjax(auto='[[shouldFetchAllNamespaces(ownedNamespace, isClusterAdmin)]]', url='/api/workgroup/get-all-namespaces',
     last-response='{{allNamespaces}}', on-error='onAllNamespaceFetchError', handle-as='json')
 section#Main-Content
@@ -25,14 +23,17 @@ section#Main-Content
                 vaadin-grid-column(width='15em', path='0', flex-grow='2', header='Namespaces')
                 vaadin-grid-column(width='9em', path='1', header='Your role')
     article.Contributors(hidden$='[[empty(ownedNamespace)]]')
-        h2
-            iron-icon.icon(icon='kubeflow:namespace')
-            span.text Contributors to your namespace - [[ownedNamespace.namespace]]
-        .content.small
-            md2-input(label='Email Addresses', value='{{newContribEmail}}', on-submit='addNewContrib', placeholder='Add by email address', error$='[[contribCreateError]]')
-                .prefix(slot='prefix')
-                    template(is='dom-repeat', items='[[contributorList]]')
-                        paper-chip(on-remove='removeContributor') [[item]]
+        template(is='dom-repeat', items='[[multiOwnedNamespaces]]' as='multiOwnedNamespace')
+            iron-ajax#GetContribsAjax(auto='[[!empty(ownedNamespace)]]', url='/api/workgroup/get-contributors/[[multiOwnedNamespace.namespace]]',
+            last-response='{{multiOwnedNamespace.contributorList}}', on-error='onContribFetchError', handle-as='json')
+            h2
+                iron-icon.icon(icon='kubeflow:namespace')
+                span.text Contributors to your namespace - [[multiOwnedNamespace.namespace]]
+            .content.small
+                md2-input(label='Email Addresses', value='{{newContribEmail}}', on-submit='addNewContrib', placeholder='Add by email address', error$='[[contribCreateError]]')
+                    .prefix(slot='prefix')
+                        template(is='dom-repeat', items='{{multiOwnedNamespace.contributorList}}')
+                            paper-chip(on-remove='removeContributor') [[item]]
     article.Cluster-Namespaces(hidden$='[[empty(isClusterAdmin)]]')
         h2
             iron-icon.icon(icon='kubeflow:namespace')

--- a/components/centraldashboard/public/components/manage-users-view.pug
+++ b/components/centraldashboard/public/components/manage-users-view.pug
@@ -1,9 +1,5 @@
 h1 Manage Contributors
-iron-ajax#RemoveContribAjax(method='DELETE', url='/api/workgroup/remove-contributor/[[ownedNamespace.namespace]]',
-    on-response='handleContribDelete', on-error='handleContribDelete', handle-as='json', content-type='application/json')
-iron-ajax#AddContribAjax(method='POST', url='/api/workgroup/add-contributor/[[ownedNamespace.namespace]]',
-    on-response='handleContribCreate', on-error='handleContribCreate', handle-as='json', content-type='application/json')
-iron-ajax#GetAllNamespacesAjax(auto='[[shouldFetchAllNamespaces(ownedNamespace, isClusterAdmin)]]', url='/api/workgroup/get-all-namespaces',
+iron-ajax#GetAllNamespacesAjax(auto='[[shouldFetchAllNamespaces(multiOwnedNamespaces, isClusterAdmin)]]', url='/api/workgroup/get-all-namespaces',
     last-response='{{allNamespaces}}', on-error='onAllNamespaceFetchError', handle-as='json')
 section#Main-Content
     article.Acct-Info
@@ -13,27 +9,18 @@ section#Main-Content
             span(hidden$='[[!isClusterAdmin]]') &nbsp; (Cluster Admin)
         .content
             span [[user]]
-    h2#NoNamespaceError(hidden$='[[!empty(ownedNamespace)]]') You have no owned namespaces!
-    article.Namespaces(hidden$='[[empty(ownedNamespace)]]')
+    h2#NoNamespaceError(hidden$='[[!empty(multiOwnedNamespaces)]]') You have no owned namespaces!
+    article.Namespaces(hidden$='[[empty(multiOwnedNamespaces)]]')
         h2
             iron-icon.icon(icon='kubeflow:namespace')
             span.text Namespace memberships
         .content.small
-            vaadin-grid(items='[[nsBreakdown(namespaces, ownedNamespace)]]', theme="no-border", height-by-rows, multi-sort)
+            vaadin-grid(items='[[nsBreakdown(namespaces)]]', theme="no-border", height-by-rows, multi-sort)
                 vaadin-grid-column(width='15em', path='0', flex-grow='2', header='Namespaces')
                 vaadin-grid-column(width='9em', path='1', header='Your role')
-    article.Contributors(hidden$='[[empty(ownedNamespace)]]')
+    article.Contributors(hidden$='[[empty(multiOwnedNamespaces)]]')     
         template(is='dom-repeat', items='[[multiOwnedNamespaces]]' as='multiOwnedNamespace')
-            iron-ajax#GetContribsAjax(auto='[[!empty(ownedNamespace)]]', url='/api/workgroup/get-contributors/[[multiOwnedNamespace.namespace]]',
-            last-response='{{multiOwnedNamespace.contributorList}}', on-error='onContribFetchError', handle-as='json')
-            h2
-                iron-icon.icon(icon='kubeflow:namespace')
-                span.text Contributors to your namespace - [[multiOwnedNamespace.namespace]]
-            .content.small
-                md2-input(label='Email Addresses', value='{{newContribEmail}}', on-submit='addNewContrib', placeholder='Add by email address', error$='[[contribCreateError]]')
-                    .prefix(slot='prefix')
-                        template(is='dom-repeat', items='{{multiOwnedNamespace.contributorList}}')
-                            paper-chip(on-remove='removeContributor') [[item]]
+            manage-users-view-contributor(owned-namespace='[[multiOwnedNamespace]]')
     article.Cluster-Namespaces(hidden$='[[empty(isClusterAdmin)]]')
         h2
             iron-icon.icon(icon='kubeflow:namespace')
@@ -43,9 +30,6 @@ section#Main-Content
                 vaadin-grid-column(width='9em', path='0', header='Namespace')
                 vaadin-grid-column(width='10em', path='1', header='Owner')
                 vaadin-grid-column(width='15em', path='2', flex-grow='2', header='Contributors')
-paper-toast#ContribError(duration=5000)
-    | Failed to fetch contributor list for {{ownedNamespace.namespace}}, because: 
-    strong [[contribError]]
 paper-toast#AllNamespaceError(duration=5000)
     | Failed to fetch all namespaces, because:
     strong [[allNamespaceError]]

--- a/components/centraldashboard/public/components/manage-users-view_test.js
+++ b/components/centraldashboard/public/components/manage-users-view_test.js
@@ -17,6 +17,7 @@ const TEMPLATE = `
 `;
 const user = 'test@kubeflow.org';
 const oNs = {namespace: 'ns1', role: 'owner'};
+const multiONs= [oNs];
 const generalNs = [oNs, {namespace: 'ns2', role: 'contributor', user}, {namespace: 'ns3', role: 'contributor', user}];
 
 describe('Manage Users View', () => {
@@ -54,14 +55,8 @@ describe('Manage Users View', () => {
     });
 
     it('UI State should show user / contribs and unhide sections when namespace available', async () => {
-        const contribList = ['foo@kubeflow.org', 'bar@kubeflow.org'];
-        mockIronAjax(
-            manageUsersView.$.GetContribsAjax,
-            contribList,
-        );
-
         manageUsersView.user = user;
-        manageUsersView.ownedNamespace = oNs;
+        manageUsersView.multiOwnedNamespaces = multiONs;
         manageUsersView.namespaces = generalNs;
 
         flush();
@@ -74,20 +69,12 @@ describe('Manage Users View', () => {
         expect(manageUsersView.shadowRoot.querySelector('.Contributors')
             .hasAttribute('hidden')).toBe(false, 'Contributors was still hidden');
         expect(manageUsersView.shadowRoot.querySelector('.Cluster-Namespaces')
-            .hasAttribute('hidden')).toBe(true, 'Cluster Namespaces should have been hidden');
-        expect(manageUsersView.shadowRoot.querySelector('.Contributors > h2 > .text').innerText)
-            .toBe('Contributors to your namespace - ns1');
-
+            .hasAttribute('hidden')).toBe(true, 'Cluster Namespaces should have been hidden');       
         // View prop expectations
         expect(manageUsersView.shadowRoot.querySelector('.Namespaces vaadin-grid').items)
             .toEqual(
-                [['ns1', 'Owner'], ['ns2, ns3', 'Contributor']],
+                [['ns1', 'Owner'], ['ns2', 'Contributor'], ['ns3', 'Contributor']],
                 'Invalid namespace memberships'
-            );
-        expect(manageUsersView.contributorList)
-            .toEqual(
-                contribList,
-                'Invalid list of contributors'
             );
     });
 
@@ -97,17 +84,13 @@ describe('Manage Users View', () => {
             ['ns1', user, contribList.join(', ')],
         ];
         mockIronAjax(
-            manageUsersView.$.GetContribsAjax,
-            contribList,
-        );
-        mockIronAjax(
             manageUsersView.$.GetAllNamespacesAjax,
             allPeeps,
         );
 
         manageUsersView.user = user;
         manageUsersView.isClusterAdmin = true;
-        manageUsersView.ownedNamespace = oNs;
+        manageUsersView.multiOwnedNamespaces = multiONs;
         manageUsersView.namespaces = [oNs];
 
         flush();
@@ -121,92 +104,6 @@ describe('Manage Users View', () => {
             .toEqual(
                 allPeeps,
                 'Invalid list of all namespace memberships'
-            );
-    });
-
-    it('Should handle errors correctly', async () => {
-        mockIronAjax(
-            manageUsersView.$.GetContribsAjax,
-            'Failed for test',
-            true,
-        );
-
-        manageUsersView.user = user;
-        manageUsersView.ownedNamespace = oNs;
-        manageUsersView.namespaces = [oNs];
-
-        flush();
-        await yieldForRequests();
-
-        expect(manageUsersView.$.ContribError.opened)
-            .toBe(
-                true,
-                'Error toast is not opened'
-            );
-        expect(manageUsersView.contribError)
-            .toBe('Failed for test');
-    });
-
-    it('Should add contributors correctly', async () => {
-        const contribList = ['foo@kubeflow.org', 'bar@kubeflow.org'];
-        const verificationContribs = ['ap@kubeflow.org'];
-        mockIronAjax(
-            manageUsersView.$.GetContribsAjax,
-            contribList,
-        );
-        mockIronAjax(
-            manageUsersView.$.AddContribAjax,
-            verificationContribs,
-        );
-
-        manageUsersView.user = user;
-        manageUsersView.ownedNamespace = oNs;
-        manageUsersView.namespaces = generalNs;
-
-        flush();
-        await yieldForRequests();
-
-        const input = manageUsersView.shadowRoot.querySelector('.Contributors md2-input');
-        input.value = 'new@google.com';
-        input.fireEnter();
-
-        await yieldForRequests();
-
-        expect(manageUsersView.contributorList)
-            .toEqual(
-                verificationContribs,
-                'Invalid list of contributors'
-            );
-    });
-
-    it('Should remove contributors correctly', async () => {
-        const contribList = ['foo@kubeflow.org', 'bar@kubeflow.org'];
-        const verificationContribs = ['ap@kubeflow.org'];
-        mockIronAjax(
-            manageUsersView.$.GetContribsAjax,
-            contribList,
-        );
-        mockIronAjax(
-            manageUsersView.$.RemoveContribAjax,
-            verificationContribs,
-        );
-
-        manageUsersView.user = user;
-        manageUsersView.ownedNamespace = oNs;
-        manageUsersView.namespaces = generalNs;
-
-        flush();
-        await yieldForRequests();
-
-        const chip = manageUsersView.shadowRoot.querySelector('.Contributors md2-input paper-chip:nth-of-type(1)');
-        chip.fireRemove({});
-
-        await yieldForRequests();
-
-        expect(manageUsersView.contributorList)
-            .toEqual(
-                verificationContribs,
-                'Invalid list of contributors'
             );
     });
 });


### PR DESCRIPTION
**Incomplete WIP, do not merge:** to be continued by somebody else, as I am switching over to another team.

Will resolve https://github.com/StatCan/kubeflow/issues/7 when finished.

Preliminary steps to work on this:
1. Clone this branch and navigate to `kubeflow/components/centraldashboard`
2. Install node **v12.18.3** and make sure you are using it (`node -v`). [nvm](https://github.com/nvm-sh/nvm) is very handy for this!
3. `make build-local`
4. `kubectl apply` another [profile](https://www.kubeflow.org/docs/components/multi-tenancy/getting-started/#manual-profile-creation) setting yourself as the owner. No need for the `resourceQuotaSpec` section, that can be removed entirely. If you lack permissions for this, ping me and I can do that for you.
5. In another terminal, on a cluster running Kubeflow, do `kubectl port-forward -n kubeflow deployment/profiles-deployment 8081:8081`. This will enable the Manage Contributors section. Other areas of the sidebar and main page will remain unconnected in the following step, but they are not necessary for this issue.
6. Back in the centraldashboard directory, run `USERID_HEADER=kubeflow-userid USERID_PREFIX= KF_USER_ID=[name@cloud.statcan.ca, e.g. frances.zsurka@cloud.statcan.ca] npm run dev`. 

Sometimes for me the last step will not run, complaining of too many watchers. This seems to be a RAM issue on my end (or at least I've tried increasing `fs.inotify.max_user_watches` without effect). Closing my browser and/or VS Code helps. Re-opening them after the server has started works fine, and the server automatically applies code changes. 

What I got working:
- In `main-page.js`, when the array of namespaces for a user is loaded, it is now sorted into an array of "owner" role namespaces and other role namespaces. The owner array is put before the other array, so that owned namespaces will appear at the top of the namespace dropdown as well as the namespace membership list on the Manage Contributors page. 
- The owned namespaces array is set as the value of a new main page class property, `this.multiOwnedNamespaces`. multiOwnedNamespaces is something I would like to have a better name for later, as it is confusing (these are multiple owned namespaces, not e.g. namespaces owned by multiple users), but for now I wanted something visually distinct from the existing singular property `ownedNamespace`. If all instances of `ownedNamespace` get refactored away, we could change `multiOwnedNamespaces` to the more intuitive `ownedNamespaces`.
- In `main-page.pug`, `multi-owned-namespaces='[[multiOwnedNamespaces]]'` is passed to manage-users-view. This specific case combination, `dash-case=[[camelCase]]`, has to be used for this to work. Not sure if that's a quirk of pug, Polymer, or something else.
- I reworked the namespace membership list in Manage Contributors. This was originally just an experiment to ensure that things were getting passed properly, but I found the result more usable. Originally, the membership list only ever has two rows. The alphabetically first owned namespace is "Owner", and every other namespace on a single line is "Contributor". If there are several other namespaces, at some point they are cut off with a "...". The new membership list has a row per namespace, lists the owner roles first, and hypothetically accepts roles other than "Contributor" (not that any exist now). A helper function capitalizes the first letter of the role name to be in line with the original appearance.
 - All owned namespaces, and only owned namespaces, are listed in multiple "Contributors to your namespace - [namespace name]" section, with the appropriate namespace name and the appropriate list of contributors. I had considered an alternate approach where a single owned namespace would be selected from the dropdown, which would set and continue to use the singular ownedNamespace. But that presented its own challenges and seems a lot clunkier: I think it makes the most sense to see the contributors to your namespaces, and thus be able to tell exactly where a particular contributor is/isn't, all at once. But if the issues below can't be easily resolved, perhaps the one-at-a-time approach is worth reconsidering. 

Where I got stuck:
The list of multiple owned namespaces was done with a `dom-repeat`, but that may be the wrong method (or something may be missing from it). When a new email is typed into any contributor field (`Add by email address`), character by character, it appears in _every_ contributor field. I'm still not entirely sure what's going on under the hood here or how to properly instantiate/differentiate these elements. It might have something to do with the `this.contributorInputEl = this.$.ContribEmail;` line in `manage-users-view.js`.

Furthermore, I could not get the add or remove contributor iron-ajax methods to work. In this commit, I left them in their default state, where any email entered, or removal enacted, will apply to only the alphabetically first owned namespace. There is no update for this visually until a refresh. If I move them to the same location I moved `GetContribsAjax` to, and have them likewise target `[[multiOwnedNamespace.namespace]]`, nothing happens: console log will say that `api` is undefined, with the corresponding failing code in `main-users-view.js` being `const api = this.$.AddContribAjax;` and `const api = this.$.RemoveContribAjax;`. 

So if I'm even on the right track, it may be important to puzzle out exactly how `this.$` behaves and how that interacts with `dom-repeat`. Some old discussions and documentation I've come across note that `this.$` cannot get elements from inside of a `dom-repeat`, but they seem to be for older versions of Polymer, so I'm not certain whether that's still the case (or what the best workaround is).

I've also tried the iron-ajax lower down where the contributors are being templated, as well as its `model` syntax. No luck, but might not have found the appropriate combination if one exists.

Note that any Polymer syntax found in documentation and discussions will look different from what's in the .pug files. Pug is a templating engine that will compile into the appropriate code.

What remains:
- [X] Successfully add contributors to a specific owned namespace
- [x] Successfully remove contributors from a specific owned namespace
- [x] Confirm whether there are more AJAX requests than necessary (and if so refactor)
- [x] Check if there are any other problematic areas where a singular `ownedNamespace` is assumed
-  If it is possible to refactor all singular instances of `ownedNamespace` into plural ones, consider renaming what is currently `multiOwnedNamespaces` to just `ownedNamespaces`
- [x] If any of the not-directly-related changes (dropdown re-order, Namespace memberships list change) are deemed unnecessary or suited for other issues, revert them (and if necessary replace with a different way to get owned namespaces)
- [x] If necessary, update `public/components/main-page_test.js` [(Jasmine)](https://jasmine.github.io/) so that the docker image can build.
- [x] Update `public/components/main-users-view_test.js` [(Jasmine)](https://jasmine.github.io/) so that the docker image can build.

A side-issue:

I noticed that when after being the owner of more than one profile, when I refresh my Notebook Servers page (on the regular production website; haven't gotten this to load with `npm run dev`), sometimes but not always, it will switch to the first owned namespace alphabetically. 

Whether the switch happens seems to depend on whether my URL specifies e.g. `_/jupyter/?ns=frances-zsurka` (no switch) or not (just `_/jupyter/` switches on refresh). And if I have the `?ns=frances-zsurka` parameter, and I refresh that page, then click anywhere on that page, that `?ns=frances-zsurka` parameter is lost and the following refresh will switch to the first owned namespace alphabetically. 

It is a minor annoyance and most likely suited to a separate issue (I suggest creating one, perhaps after this is sorted and multiple namespaces will be more broadly used), but I am mentioning it here in case there's a way to refactor to multiple owned namespaces that would also address this. If not another avenue would be to prevent the loss of `?ns=[namespace]` parameter.