### PR TITLE
feat(centraldashboard): add pipeline items to left menu as top-level items

### DIFF
--- a/components/centraldashboard/config/centraldashboard-config.yaml
+++ b/components/centraldashboard/config/centraldashboard-config.yaml
@@ -11,14 +11,46 @@ data:
       { 
         "menuLinks": [
         {
+          "type": "item",
+          "link": "/jupyter/",
+          "text": "Notebooks",
+          "icon": "book"
+        },
+        {
+          "type": "item",
           "link": "/pipeline/",
           "text": "Pipelines",
           "icon": "kubeflow:pipeline-centered"
         },
         {
-          "link": "/jupyter/",
-          "text": "Notebooks",
-          "icon": "book"
+          "type": "item",
+          "text": "Experiments (KFP)",
+          "link": "/pipeline/#/experiments",
+          "icon": "done-all"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/runs",
+          "text": "Runs",
+          "icon": "maps:directions-run"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/recurringruns",
+          "text": "Recurring Runs",
+          "icon": "device:access-alarm"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/artifacts",
+          "text": "Artifacts",
+          "icon": "editor:bubble-chart"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/executions",
+          "text": "Executions",
+          "icon": "av:play-arrow"
         },
         {
           "link": "/katib/",
@@ -76,14 +108,46 @@ data:
       {
         "menuLinks": [
         {
+          "type": "item",
+          "link": "/jupyter/",
+          "text": "Serveur Bloc-notes",
+          "icon": "book"
+        },
+        {
+          "type": "item",
           "link": "/pipeline/",
           "text": "Pipelines",
           "icon": "kubeflow:pipeline-centered"
         },
         {
-          "link": "/jupyter/",
-          "text": "Serveur Bloc-notes",
-          "icon": "book"
+          "type": "item",
+          "text": "Expériences (KFP)",
+          "link": "/pipeline/#/experiments",
+          "icon": "done-all"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/runs",
+          "text": "Exécutions",
+          "icon": "maps:directions-run"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/recurringruns",
+          "text": "Exécutions récurrentes",
+          "icon": "device:access-alarm"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/artifacts",
+          "text": "Artefacts",
+          "icon": "editor:bubble-chart"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/executions",
+          "text": "Exécutions en cours",
+          "icon": "av:play-arrow"
         },
         {
           "link": "/katib/",


### PR DESCRIPTION
With upgrade to KF 1.3, Pipelines no longer has it's own menu. This PR adds those items to the main left menu as top-level items.

Closes https://github.com/StatCan/daaas/issues/838

cc @rohank07