### PR TITLE
feat(notebook-controller): add readiness probe

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -350,6 +350,18 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 		Value: "/notebook/" + instance.Namespace + "/" + instance.Name,
 	})
 
+	// Add readiness probe
+	if container.ReadinessProbe == nil {
+		container.ReadinessProbe = &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/notebook/" + instance.Namespace + "/" + instance.Name,
+					Port: intstr.FromInt(DefaultContainerPort),
+				},
+			},
+		}
+	}
+
 	// For some platforms (like OpenShift), adding fsGroup: 100 is troublesome.
 	// This allows for those platforms to bypass the automatic addition of the fsGroup
 	// and will allow for the Pod Security Policy controller to make an appropriate choice


### PR DESCRIPTION
Adds a readiness probe to all notebooks without one.

Closes Statcan/daaas#339