### PR TITLE
fix(ci): update notebook-controller ci

### DIFF
--- a/.github/workflows/build-notebookcontroller.yml
+++ b/.github/workflows/build-notebookcontroller.yml
@@ -43,11 +43,12 @@ jobs:
       # Container build and push to a Azure Container registry (ACR)
       - name: Docker build/push
         run: |
-          docker build \
+          cd components
+          docker build . \
             -t ${{ env.REGISTRY_NAME }}.azurecr.io/kubeflow/notebook-controller:${{ github.sha }} \
             --build-arg kubeflowversion=$(git describe --abbrev=0 --tags) \
             --build-arg commit=$(git rev-parse HEAD) \
-            components/notebook-controller/
+            -f notebook-controller/Dockerfile
           docker push ${{ env.REGISTRY_NAME }}.azurecr.io/kubeflow/notebook-controller:${{ github.sha }}
           docker tag ${{ env.REGISTRY_NAME }}.azurecr.io/kubeflow/notebook-controller:${{ github.sha }} \
             ${{ env.REGISTRY_NAME }}.azurecr.io/kubeflow/notebook-controller:${GITHUB_REF#refs/*/}


### PR DESCRIPTION
Update workflow to build from components folder because copying the notebook-controller directory requires you to be in parent folder, and building an image while being in the parent folder needs the -f flag to specify the Dockerfile.

Related to StatCan/daaas#339