### PR TITLE
Restore notebook controller

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -462,20 +462,6 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 		}
 	}
 
-	// Begin AAW Addition
-	// Add readiness probe
-	if container.ReadinessProbe == nil {
-		container.ReadinessProbe = &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/notebook/" + instance.Namespace + "/" + instance.Name,
-					Port: intstr.FromInt(DefaultContainerPort),
-				},
-			},
-		}
-	}
-	// End AAW Addition
-
 	setPrefixEnvVar(instance, container)
 
 	// For some platforms (like OpenShift), adding fsGroup: 100 is troublesome.


### PR DESCRIPTION
There were issues with the go code when upgrading notebook-controller to v1.6. Resetting to upstream with `git restore --source upstream/v1.6-branch components/notebook-controller/`.