### PR TITLE
fix(api_default): fix CreateBinding error response

### DIFF
--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -144,7 +144,9 @@ func (c *KfamV1Alpha1Client) CreateBinding(w http.ResponseWriter, r *http.Reques
 		useremail, profileName.Name, internal_fdi_bucket, binding.User.Name)
 	// respond forbidden if label is set and attempted to add non-internal user email
 	if !internalUser(binding.User.Name) && internal_fdi_bucket {
-		IncRequestCounter("forbidden: Internal FDI Bucket exists", useremail, action, r.URL.Path)
+		IncRequestErrorCounter("forbidden: Internal FDI Bucket exists", useremail, action, r.URL.Path,
+			SEVERITY_MAJOR)
+		writeResponse(w, []byte(err.Error()))
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}

--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -178,8 +178,8 @@ func (c *KfamV1Alpha1Client) CreateProfile(w http.ResponseWriter, r *http.Reques
 	if err := json.NewDecoder(r.Body).Decode(&profile); err != nil {
 		IncRequestErrorCounter("decode error", "", action, r.URL.Path,
 			SEVERITY_MAJOR)
-		writeResponse(w, []byte(err.Error()))
 		w.WriteHeader(http.StatusForbidden)
+		writeResponse(w, []byte(err.Error()))
 		return
 	}
 	_, err := c.profileClient.Create(&profile)
@@ -201,8 +201,8 @@ func (c *KfamV1Alpha1Client) DeleteBinding(w http.ResponseWriter, r *http.Reques
 	if err := json.NewDecoder(r.Body).Decode(&binding); err != nil {
 		IncRequestErrorCounter("decode error", "", action, r.URL.Path,
 			SEVERITY_MAJOR)
-		writeResponse(w, []byte(err.Error()))
 		w.WriteHeader(http.StatusForbidden)
+		writeResponse(w, []byte(err.Error()))
 		return
 	}
 	// check permission before delete

--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -12,6 +12,7 @@ package kfam
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"path"
@@ -144,6 +145,7 @@ func (c *KfamV1Alpha1Client) CreateBinding(w http.ResponseWriter, r *http.Reques
 		useremail, profileName.Name, internal_fdi_bucket, binding.User.Name)
 	// respond forbidden if label is set and attempted to add non-internal user email
 	if !internalUser(binding.User.Name) && internal_fdi_bucket {
+		err := errors.New("forbidden: an attempt to add an external user to a namespace with internal fdi Bucket was made")
 		IncRequestErrorCounter("forbidden: Internal FDI Bucket exists", useremail, action, r.URL.Path,
 			SEVERITY_MAJOR)
 		writeResponse(w, []byte(err.Error()))

--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -114,8 +114,8 @@ func (c *KfamV1Alpha1Client) CreateBinding(w http.ResponseWriter, r *http.Reques
 	if err := json.NewDecoder(r.Body).Decode(&binding); err != nil {
 		IncRequestErrorCounter("decode request error", "", action, r.URL.Path,
 			SEVERITY_MAJOR)
-		writeResponse(w, []byte(err.Error()))
 		w.WriteHeader(http.StatusForbidden)
+		writeResponse(w, []byte(err.Error()))
 		return
 	}
 	// check permission before create binding
@@ -127,8 +127,8 @@ func (c *KfamV1Alpha1Client) CreateBinding(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		IncRequestErrorCounter("Profile fetch failed", "", action, r.URL.Path,
 			SEVERITY_MAJOR)
-		writeResponse(w, []byte(err.Error()))
 		w.WriteHeader(http.StatusForbidden)
+		writeResponse(w, []byte(err.Error()))
 		return
 	}
 	// check value of label
@@ -136,8 +136,8 @@ func (c *KfamV1Alpha1Client) CreateBinding(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		IncRequestErrorCounter("Label parse failed", "", action, r.URL.Path,
 			SEVERITY_MAJOR)
-		writeResponse(w, []byte(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
+		writeResponse(w, []byte(err.Error()))
 		return
 	}
 
@@ -146,10 +146,11 @@ func (c *KfamV1Alpha1Client) CreateBinding(w http.ResponseWriter, r *http.Reques
 	// respond forbidden if label is set and attempted to add non-internal user email
 	if !internalUser(binding.User.Name) && internal_fdi_bucket {
 		err := errors.New("forbidden: an attempt to add an external user to a namespace with internal fdi Bucket was made")
+		log.Printf(err.Error())
 		IncRequestErrorCounter("forbidden: Internal FDI Bucket exists", useremail, action, r.URL.Path,
 			SEVERITY_MAJOR)
-		writeResponse(w, []byte(err.Error()))
 		w.WriteHeader(http.StatusForbidden)
+		writeResponse(w, []byte(err.Error()))
 		return
 	}
 

--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -146,7 +146,6 @@ func (c *KfamV1Alpha1Client) CreateBinding(w http.ResponseWriter, r *http.Reques
 	// respond forbidden if label is set and attempted to add non-internal user email
 	if !internalUser(binding.User.Name) && internal_fdi_bucket {
 		err := errors.New("forbidden: an attempt to add an external user to a namespace with internal fdi Bucket was made")
-		log.Printf(err.Error())
 		IncRequestErrorCounter("forbidden: Internal FDI Bucket exists", useremail, action, r.URL.Path,
 			SEVERITY_MAJOR)
 		w.WriteHeader(http.StatusForbidden)

--- a/components/centraldashboard/public/assets/i18n/languages.json
+++ b/components/centraldashboard/public/assets/i18n/languages.json
@@ -206,7 +206,7 @@
             "manageUsersViewContributor.phdAddByEmail":"Ajouter par adresse courriel",
             "manageUsersViewContributor.errorContributor": "Échec de la récupération de la liste de contributeurs pour {ownedNamespace}, car:",
             "manageUsersViewContributor.errorCreateGeneral": "Échec lors de l'ajout d'un courriel. Veuillez vous assurez que le format est valide et qu'il n'y a pas de duplicat dans cet espace de noms.",
-            "manageUsersViewContributor.errorCreateFDI": "Ne peut pas ajouter un utilisateur externe à un espace de noms qui contient des buckets seulement internes. Veuillez contacter l'équipe d'AAW",
+            "manageUsersViewContributor.errorCreateFDI": "Ne peut pas ajouter un utilisateur externe à un espace de noms qui contient des seaux seulement internes. Veuillez contacter l'équipe d'ETAA",
             "manageUsersViewContributor.errorDeleteGeneral": "Échec lors de la supression du courriel. Veuillez réessayer.",
             "s3Proxy.defaultMessage": "Cet espace de noms n'inclue pas S3 proxy. Pour commencer à utiliser S3 proxy, veuilliez choisir de participer au service."
         }

--- a/components/centraldashboard/public/assets/i18n/languages.json
+++ b/components/centraldashboard/public/assets/i18n/languages.json
@@ -101,6 +101,7 @@
             "manageUsersViewContributor.phdAddByEmail":"Add by email address",
             "manageUsersViewContributor.errorContributor": "Failed to fetch contributor list for {ownedNamespace}, because:",
             "manageUsersViewContributor.errorCreateGeneral": "An error occured while trying to add the email. Please make check the email format and make sure there are no duplicates in this namespace.",
+            "manageUsersViewContributor.errorCreateFDI": "Cannot add an external user to a namespace containing internal only buckets. Please contact the AAW team.",
             "manageUsersViewContributor.errorDeleteGeneral": "An error occured while trying to remove the email. Please try again.",
             "s3Proxy.defaultMessage": "This namespace does not include S3 proxy. To start using S3 proxy, please opt in to the service."
         },
@@ -205,6 +206,7 @@
             "manageUsersViewContributor.phdAddByEmail":"Ajouter par adresse courriel",
             "manageUsersViewContributor.errorContributor": "Échec de la récupération de la liste de contributeurs pour {ownedNamespace}, car:",
             "manageUsersViewContributor.errorCreateGeneral": "Échec lors de l'ajout d'un courriel. Veuillez vous assurez que le format est valide et qu'il n'y a pas de duplicat dans cet espace de noms.",
+            "manageUsersViewContributor.errorCreateFDI": "Ne peut pas ajouter un utilisateur externe à un espace de noms qui contient des buckets seulement internes. Veuillez contacter l'équipe d'AAW",
             "manageUsersViewContributor.errorDeleteGeneral": "Échec lors de la supression du courriel. Veuillez réessayer.",
             "s3Proxy.defaultMessage": "Cet espace de noms n'inclue pas S3 proxy. Pour commencer à utiliser S3 proxy, veuilliez choisir de participer au service."
         }

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -81,8 +81,6 @@ export class ManageUsersViewContributor extends utilitiesMixin(localizationMixin
     handleContribCreate(e) {
         if (e.detail.error) {
             const error = this._isolateErrorFromIronRequest(e);
-            // eslint-disable-next-line no-console
-            console.log(error);
             if (error.search('fdi') == -1) {
                 this.contribCreateError =
                     'manageUsersViewContributor.errorCreateGeneral';

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -80,7 +80,9 @@ export class ManageUsersViewContributor extends utilitiesMixin(localizationMixin
      */
     handleContribCreate(e) {
         if (e.detail.error) {
-            // const error = this._isolateErrorFromIronRequest(e);
+            const error = this._isolateErrorFromIronRequest(e);
+            // eslint-disable-next-line no-console
+            console.log(error);
             this.contribCreateError =
                 'manageUsersViewContributor.errorCreateGeneral';
             return;

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -81,7 +81,7 @@ export class ManageUsersViewContributor extends utilitiesMixin(localizationMixin
     handleContribCreate(e) {
         if (e.detail.error) {
             const error = this._isolateErrorFromIronRequest(e);
-            if (error.search('fdi') == -1) {
+            if (error.search('fdi') === -1) {
                 this.contribCreateError =
                     'manageUsersViewContributor.errorCreateGeneral';
                 return;

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -83,9 +83,15 @@ export class ManageUsersViewContributor extends utilitiesMixin(localizationMixin
             const error = this._isolateErrorFromIronRequest(e);
             // eslint-disable-next-line no-console
             console.log(error);
-            this.contribCreateError =
-                'manageUsersViewContributor.errorCreateGeneral';
-            return;
+            if (error.search('fdi') == -1) {
+                this.contribCreateError =
+                    'manageUsersViewContributor.errorCreateGeneral';
+                return;
+            } else {
+                this.contribCreateError =
+                    'manageUsersViewContributor.errorCreateFDI';
+                return;
+            }
         }
         this.contributorList = e.detail.response;
         this.newContribEmail = this.contribCreateError = '';


### PR DESCRIPTION
Closes https://github.com/StatCan/aaw/issues/1746

- changes the order which the responses are written in KFAM to comply with https://cs.opensource.google/go/go/+/refs/tags/go1.17.1:src/net/http/server.go;l=120. This is also a bug in upstream. Causes erroneous `200` to be returned on API call, which prevents the error from being picked up.
- adds logic in central dashboard to parse the error produced from the kfam api call
- produces a custom error message on addition of external users to namespaces with internal buckets

![image](https://github.com/StatCan/kubeflow/assets/35379392/b6c38892-7500-4a9b-bdb6-a852c6ca566c)
