### PR TITLE
fix(centraldashboard): reverted logout button back to doing a POST request

### DIFF
--- a/.github/workflows/build-centraldashboard.yml
+++ b/.github/workflows/build-centraldashboard.yml
@@ -20,7 +20,7 @@ env:
   DEV_REGISTRY_NAME: k8scc01covidacrdev
   CLUSTER_NAME: k8s-cancentral-02-covid-aks
   CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
-  TRIVY_VERSION: "v0.57.0"
+  TRIVY_VERSION: "v0.69.2"
   TRIVY_DATABASES: '"ghcr.io/aquasecurity/trivy-db:2","public.ecr.aws/aquasecurity/trivy-db"'
   TRIVY_JAVA_DATABASES: '"ghcr.io/aquasecurity/trivy-java-db:1","public.ecr.aws/aquasecurity/trivy-java-db"'
   TRIVY_MAX_RETRIES: 5

--- a/.github/workflows/build-kfam.yml
+++ b/.github/workflows/build-kfam.yml
@@ -20,7 +20,7 @@ env:
   DEV_REGISTRY_NAME: k8scc01covidacrdev
   CLUSTER_NAME: k8s-cancentral-02-covid-aks
   CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
-  TRIVY_VERSION: "v0.57.0"
+  TRIVY_VERSION: "v0.69.2"
   TRIVY_DATABASES: '"ghcr.io/aquasecurity/trivy-db:2","public.ecr.aws/aquasecurity/trivy-db"'
   TRIVY_JAVA_DATABASES: '"ghcr.io/aquasecurity/trivy-java-db:1","public.ecr.aws/aquasecurity/trivy-java-db"'
   TRIVY_MAX_RETRIES: 5

--- a/.github/workflows/build-notebook-controller.yaml
+++ b/.github/workflows/build-notebook-controller.yaml
@@ -20,7 +20,7 @@ env:
   DEV_REGISTRY_NAME: k8scc01covidacrdev
   CLUSTER_NAME: k8s-cancentral-02-covid-aks
   CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
-  TRIVY_VERSION: "v0.57.0"
+  TRIVY_VERSION: "v0.69.2"
   TRIVY_DATABASES: '"ghcr.io/aquasecurity/trivy-db:2","public.ecr.aws/aquasecurity/trivy-db"'
   TRIVY_JAVA_DATABASES: '"ghcr.io/aquasecurity/trivy-java-db:1","public.ecr.aws/aquasecurity/trivy-java-db"'
   TRIVY_MAX_RETRIES: 5

--- a/components/centraldashboard/Makefile
+++ b/components/centraldashboard/Makefile
@@ -1,4 +1,4 @@
-IMG ?= centraldashboard-aaw2
+IMG ?= centraldashboard-zone
 TAG ?= $(shell git describe --tags --always --dirty)
 COMMIT = $(shell git rev-parse HEAD)
 DOCKERFILE ?= Dockerfile

--- a/components/centraldashboard/cypress/e2e/landing-page.cy.ts
+++ b/components/centraldashboard/cypress/e2e/landing-page.cy.ts
@@ -56,7 +56,7 @@ describe('Landing Page', () => {
         "kubeflowVersion": "v1beta1",
         "provider": "test_provider",
         "providerName": "azure",
-        "logoutUrl": "/logout"
+        "logoutUrl": "/authservice/logout"
       },
       "namespaces": [
         {
@@ -113,7 +113,7 @@ describe('Landing Page', () => {
         "kubeflowVersion": "v1beta1",
         "provider": "test_provider",
         "providerName": "azure",
-        "logoutUrl": "/logout"
+        "logoutUrl": "/authservice/logout"
       },
       "namespaces": [
         {

--- a/components/centraldashboard/cypress/e2e/main-page.cy.ts
+++ b/components/centraldashboard/cypress/e2e/main-page.cy.ts
@@ -79,7 +79,7 @@ describe('Main Page', () => {
         "kubeflowVersion": "v1beta1",
         "provider": "test_provider",
         "providerName": "azure",
-        "logoutUrl": "/logout"
+        "logoutUrl": "/authservice/logout"
       },
       "namespaces": [
         {

--- a/components/centraldashboard/cypress/fixtures/env-info.json
+++ b/components/centraldashboard/cypress/fixtures/env-info.json
@@ -4,7 +4,7 @@
     "kubeflowVersion": "v1beta1",
     "provider": "test_provider",
     "providerName": "azure",
-    "logoutUrl": "/logout"
+    "logoutUrl": "/authservice/logout"
   },
   "namespaces": [
     {

--- a/components/centraldashboard/manifests/base/deployment.yaml
+++ b/components/centraldashboard/manifests/base/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: DASHBOARD_CONFIGMAP
           value: CD_CONFIGMAP_NAME_PLACEHOLDER
         - name: LOGOUT_URL
-          value: '/oauth2/sign_out'
+          value: '/authservice/logout'
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/components/centraldashboard/public/components/logout-button.js
+++ b/components/centraldashboard/public/components/logout-button.js
@@ -1,33 +1,80 @@
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+
+import '@polymer/iron-ajax/iron-ajax.js';
 import '@polymer/paper-button/paper-button.js';
-import css from './logout-button.css';
 
 /**
  * Logout button component.
  * Handles the logout requests and post-logout redirects.
  *
- * AAW: Not using this compoent and the logoutURL env param. Doesn't work.
- * https://github.com/StatCan/kubeflow/issues/152
+ * ZONE: Sends a POST request to the oidc-authservice for logout.
  */
+
 export class LogoutButton extends PolymerElement {
     static get template() {
-        return html([`
-            <style>${css.toString()}</style>
-            <a href$="{{logoutUrl}}" on-tap="logout">
-                <paper-button id="logout-button">
-                    <iron-icon icon="kubeflow:logout" 
-                               title="{{localize('landingPage.btnLogout')}}">
-                    </iron-icon>
-                </paper-button>
-            </a>
-        `]);
+        return html`
+            <paper-button id="logout-button" on-tap="logout">
+                <iron-icon icon='kubeflow:logout' title="Logout">
+                </iron-icon>
+            </paper-button>
+            <iron-ajax
+                    id='logout'
+                    url$='{{logoutUrl}}'
+                    method='post'
+                    handle-as='json'
+                    headers='{{headers}}'
+                    on-response='_postLogout'>
+            </iron-ajax>
+        `;
+    }
+
+    static get properties() {
+        return {
+            headers: {
+                type: Object,
+                computed: '_setHeaders()',
+            },
+            logoutUrl: {
+                type: String,
+            },
+        };
     }
 
     /**
-     * Set current page to logoutURL.
+     * After successful logout, redirects user to `afterLogoutURL`,
+     * received from the backend.
+     *
+     * @param {{Event}} event
+     * @private
+     */
+    _postLogout(event) {
+        window.location.replace(event.detail.response['afterLogoutURL']);
+    }
+
+    /**
+     * Call logout endpoint.
      */
     logout() {
-        window.top.location.href = this.logoutUrl;
+        // call iron-ajax
+        this.$.logout.generateRequest();
+    }
+
+    /**
+     * Set 'Authorization' header based on the existing cookie.
+     * Currently, the logout method only accepts authorization header, see:
+     * https://github.com/arrikto/oidc-authservice/blob/master/server.go#L386
+     *
+     * @return {{Object}} headers
+     * @private
+     */
+    _setHeaders() {
+        const cookie = ('; ' + document.cookie)
+            .split(`; authservice_session=`)
+            .pop()
+            .split(';')[0];
+        return {
+            'Authorization': `Bearer ${cookie}`,
+        };
     }
 }
 

--- a/components/centraldashboard/public/components/logout-button.js
+++ b/components/centraldashboard/public/components/logout-button.js
@@ -2,6 +2,8 @@ import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 
 import '@polymer/iron-ajax/iron-ajax.js';
 import '@polymer/paper-button/paper-button.js';
+import '@polymer/paper-icon-button/paper-icon-button.js';
+import '@polymer/iron-icons/iron-icons.js';
 
 /**
  * Logout button component.
@@ -13,10 +15,13 @@ import '@polymer/paper-button/paper-button.js';
 export class LogoutButton extends PolymerElement {
     static get template() {
         return html`
-            <paper-button id="logout-button" on-tap="logout">
-                <iron-icon icon='kubeflow:logout' title="Logout">
-                </iron-icon>
-            </paper-button>
+            <paper-icon-button 
+                id="logout-button" 
+                icon="kubeflow:logout" 
+                on-tap="logout"
+                title="{{localize('landingPage.btnLogout')}}"
+            >
+            </paper-icon-button>
             <iron-ajax
                     id='logout'
                     url$='{{logoutUrl}}'

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -351,7 +351,7 @@ export class MainPage extends mixinBehaviors([AppLocalizeBehavior, IronResizable
 
         switch (newPage) {
         case 'logout':
-            window.top.location.href = '/logout';
+            this.$.logoutComponent.logout();
             break;
         case 'activity':
             this.page = 'activity';

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -81,8 +81,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                     user='[[user]]', language='[[language]]', resources='[[resources]]')
                 footer#User-Badge
                     paper-button.language-button(on-click='_changeLanguage') {{localize('mainPage.languageButton')}}
-                    a(target="_top", href="/logout")
-                        iron-icon.icon(icon='kubeflow:logout' title="{{localize('landingPage.btnLogout')}}")
+                    logout-button#logoutComponent(logout-url='[[logoutUrl]]')
         main#Content
             section#ViewTabs(hidden$='[[hideTabs]]')
                 paper-tabs(selected='[[page]]', attr-for-selected='page')


### PR DESCRIPTION
for https://jirab.statcan.ca/browse/ZONE-423
and https://jirab.statcan.ca/browse/ZONE-419

Reverts the logout button code to comply with the oidc-authservice instead of the oauth2-proxy, and to work with our fork of the oidc-authservice